### PR TITLE
Fix the translation word that means chapter

### DIFF
--- a/src/site/versions/chinese.md
+++ b/src/site/versions/chinese.md
@@ -9,7 +9,7 @@ translations:
     authorsLead: '由唐鳳及格倫·韋爾著作',
     translatorsLead: 'Translated by:',
     return: 'return',
-    chapters: '章节',
+    chapters: '章節',
   }
 language: { en: 'chinese', iso6392B: 'chi', locale: '華文' }
 translators:


### PR DESCRIPTION
This is to correct the translation text in data section of md files.
PR to correct the same symptom for the menu texts was raised  in https://github.com/johnhadaway/plurality.net/pull/2/commits/3d1dd246fc33cf9ead431bde2773cd341f075c41 .